### PR TITLE
Shhhh...

### DIFF
--- a/tasks/hercule.js
+++ b/tasks/hercule.js
@@ -17,9 +17,9 @@ module.exports = function (grunt) {
 					}
 					else {
 						grunt.file.write(path.join(process.cwd(), f.dest), output);
-						grunt.log.write(f.src[0]);
-						grunt.log.write(' >> '.green);
-						grunt.log.writeln(f.dest);
+//						grunt.log.write(f.src[0]);
+//						grunt.log.write(' >> '.green);
+//						grunt.log.writeln(f.dest);
 					}
 					numFiles = numFiles - 1;
 					if (numFiles === 0) {


### PR DESCRIPTION
I suppose this plugin ought to read a `debug:` or `verbose:` parameter instead, and output (or not) accordingly. Meanwhile, though, displaying a line for each successful transclusion gets extremely noisy (and slows things down) for large projects. 

Just a suggestion. :)